### PR TITLE
fix: recover from invalid GitHub credentials in new project flow (#80)

### DIFF
--- a/src/main/java/ca/weblite/jdeploy/app/controllers/MainMenuViewController.java
+++ b/src/main/java/ca/weblite/jdeploy/app/controllers/MainMenuViewController.java
@@ -1,6 +1,7 @@
 package ca.weblite.jdeploy.app.controllers;
 
 import ca.weblite.jdeploy.DIContext;
+import ca.weblite.jdeploy.app.accounts.AccountType;
 import ca.weblite.jdeploy.app.factories.ControllerFactory;
 import ca.weblite.jdeploy.app.forms.MainMenuForm;
 import ca.weblite.jdeploy.app.records.Project;
@@ -105,6 +106,25 @@ public class MainMenuViewController extends JFrameViewController {
     @Override
     protected void onBeforeShow() {
         getFrame().setTitle("jDeploy");
+        getFrame().setJMenuBar(buildMenuBar());
+    }
+
+    private JMenuBar buildMenuBar() {
+        JMenuBar menuBar = new JMenuBar();
+        JMenu accountsMenu = new JMenu("Accounts");
+
+        JMenuItem manageGitHub = new JMenuItem("Manage GitHub Accounts...");
+        manageGitHub.addActionListener(e ->
+                new AccountChooserController(getFrame(), AccountType.GITHUB).show());
+
+        JMenuItem manageNpm = new JMenuItem("Manage npm Accounts...");
+        manageNpm.addActionListener(e ->
+                new AccountChooserController(getFrame(), AccountType.NPM).show());
+
+        accountsMenu.add(manageGitHub);
+        accountsMenu.add(manageNpm);
+        menuBar.add(accountsMenu);
+        return menuBar;
     }
 
     private ListModel<Project> buildRecentProjectsModel() {

--- a/src/main/java/ca/weblite/jdeploy/app/controllers/NewProjectController.kt
+++ b/src/main/java/ca/weblite/jdeploy/app/controllers/NewProjectController.kt
@@ -3,17 +3,20 @@ package ca.weblite.jdeploy.app.controllers
 import ca.weblite.jdeploy.app.accounts.AccountInterface
 import ca.weblite.jdeploy.app.accounts.AccountType
 import ca.weblite.jdeploy.DIContext
+import ca.weblite.jdeploy.app.exceptions.GitHubAuthException
 import ca.weblite.jdeploy.app.exceptions.ValidationFailedException
 import ca.weblite.jdeploy.app.factories.ControllerFactory
 import ca.weblite.jdeploy.app.forms.NewProjectForm
 import ca.weblite.jdeploy.app.system.files.FileSystemUiInterface
 import ca.weblite.jdeploy.builders.ProjectGeneratorRequestBuilder
+import ca.weblite.jdeploy.services.GitHubUsernameService
 import ca.weblite.jdeploy.services.GithubTokenService
 import ca.weblite.jdeploy.services.ProjectGenerator
 import ca.weblite.jdeploy.services.ProjectTemplateCatalog
 import java.awt.FlowLayout
 import java.awt.Frame
 import java.io.File
+import java.io.IOException
 import java.util.concurrent.CompletableFuture
 import java.util.prefs.Preferences
 import javax.swing.*
@@ -26,6 +29,7 @@ class NewProjectController(
     private val templateCatalog: ProjectTemplateCatalog,
     private val controllerFactory: ControllerFactory,
     private val githubTokenService: GithubTokenService = DIContext.get(GithubTokenService::class.java),
+    private val gitHubUsernameService: GitHubUsernameService = DIContext.get(GitHubUsernameService::class.java),
 ) {
     private lateinit var dialog: NewProjectForm
 
@@ -186,11 +190,18 @@ class NewProjectController(
     }
 
     private fun requiresGithubLogin(): Boolean {
+        return isGitHubRepositoryRequested()
+    }
+
+    /**
+     * Whether project creation will create/push a GitHub repository and therefore
+     * needs valid GitHub credentials. This must mirror the condition in
+     * [createProject] that sets the github repository on the request.
+     */
+    private fun isGitHubRepositoryRequested(): Boolean {
         return dialog.gitHubReleasesRadioButton.isSelected
-                && (
-                dialog.createGithubReleasesRepositoryCheckBox.isSelected
-                        || dialog.createGithubRepositoryUrlCheckBox.isSelected
-                )
+                && dialog.createGithubRepositoryUrlCheckBox.isSelected
+                && dialog.githubRepositoryUrl.text.isNotEmpty()
     }
 
     private fun handleCreateProject() {
@@ -210,6 +221,9 @@ class NewProjectController(
         // Define the SwingWorker
         val worker = object : SwingWorker<File, File>() {
             override fun doInBackground(): File {
+                // Verify the GitHub credentials up front so we fail fast with a
+                // clear message instead of part way through generation with a 401.
+                validateGitHubTokenIfNeeded()
                 // Perform the long-running project creation task
                 val projectDirectory = createProject()
                 saveDefaultValues()
@@ -218,15 +232,19 @@ class NewProjectController(
             }
 
             override fun done() {
+                // Dispose of the progress dialog before handling the result so any
+                // follow-up dialogs (e.g. re-authentication) aren't blocked by it.
+                progressDialog.dispose()
                 try {
                     // Attempt to retrieve the result to check for exceptions
                     openProject(get())
                 } catch (e: Exception) {
-                    e.printStackTrace()
-                    controllerFactory.createErrorController(e).run()
-                } finally {
-                    // Dispose of the progress dialog
-                    progressDialog.dispose()
+                    if (isGitHubAuthError(e)) {
+                        promptReauthenticationAndRetry(e)
+                    } else {
+                        e.printStackTrace()
+                        controllerFactory.createErrorController(e).run()
+                    }
                 }
             }
         }
@@ -236,6 +254,104 @@ class NewProjectController(
 
         // Show the progress dialog (this will block the EDT if modal = true)
         progressDialog.isVisible = true
+    }
+
+    /**
+     * Validates that we have a working GitHub token before generating a project
+     * that needs one. Throws [GitHubAuthException] if no token is set or GitHub
+     * rejects it, so the create flow can prompt the user to (re-)authenticate.
+     */
+    @Throws(GitHubAuthException::class)
+    private fun validateGitHubTokenIfNeeded() {
+        if (!isGitHubRepositoryRequested()) {
+            return
+        }
+        val token = githubTokenService.token
+        if (token == null || token.isBlank()) {
+            throw GitHubAuthException("No GitHub account selected. Please choose or add a GitHub account.")
+        }
+        try {
+            gitHubUsernameService.gitHubUsername
+        } catch (e: IOException) {
+            throw GitHubAuthException(
+                "GitHub authentication failed. Your token may be invalid or expired.",
+                e
+            )
+        }
+    }
+
+    /**
+     * Detects whether the given throwable (or any of its causes) represents a
+     * GitHub authentication failure, including the raw 401 errors thrown by the
+     * jdeploy CLI before it had a dedicated auth exception type.
+     */
+    private fun isGitHubAuthError(throwable: Throwable?): Boolean {
+        var current = throwable
+        while (current != null) {
+            if (current is GitHubAuthException) {
+                return true
+            }
+            val message = current.message?.lowercase() ?: ""
+            if (message.contains("bad credentials")
+                || message.contains("response code: 401")
+                || message.contains("response code:401")
+                || message.contains("http 401")
+            ) {
+                return true
+            }
+            current = current.cause
+        }
+        return false
+    }
+
+    /**
+     * Clears the rejected token, prompts the user to pick or add a GitHub account
+     * with a valid token, then retries project creation. If the user cancels, the
+     * original error is surfaced.
+     */
+    private fun promptReauthenticationAndRetry(originalError: Throwable) {
+        // Clear the bad token so it isn't silently reused. setToken(null) would
+        // throw (Properties reject null values) so clear with an empty string.
+        githubTokenService.setToken("")
+        JOptionPane.showMessageDialog(
+            dialog,
+            "GitHub authentication failed (the credentials were rejected).\n" +
+                    "Please select or add a GitHub account with a valid personal access token.",
+            "GitHub Authentication Required",
+            JOptionPane.WARNING_MESSAGE
+        )
+        AccountChooserController(dialog, AccountType.GITHUB).show().thenAccept { account ->
+            SwingUtilities.invokeLater {
+                if (account != null && account.getAccessToken() != null) {
+                    githubTokenService.setToken(account.getAccessToken())
+                    // Remove the partially-created project from the failed attempt so
+                    // the retry doesn't trip the "directory already exists" check.
+                    cleanupPartialProject()
+                    handleCreateProject()
+                } else {
+                    controllerFactory.createErrorController(originalError).run()
+                }
+            }
+        }
+    }
+
+    /**
+     * Deletes the project directory (and its `-releases` sibling) left behind by a
+     * failed creation attempt, so the user can retry without a manual cleanup.
+     */
+    private fun cleanupPartialProject() {
+        try {
+            val projectDir = getProjectDirectory()
+            if (projectDir.exists()) {
+                projectDir.deleteRecursively()
+            }
+            val releasesDir = File(projectDir.parentFile, projectDir.name + "-releases")
+            if (releasesDir.exists()) {
+                releasesDir.deleteRecursively()
+            }
+        } catch (e: Exception) {
+            e.printStackTrace()
+        }
     }
 
     @Throws(ValidationFailedException::class)

--- a/src/main/java/ca/weblite/jdeploy/app/exceptions/GitHubAuthException.kt
+++ b/src/main/java/ca/weblite/jdeploy/app/exceptions/GitHubAuthException.kt
@@ -1,0 +1,8 @@
+package ca.weblite.jdeploy.app.exceptions
+
+/**
+ * Raised when GitHub credentials are missing, invalid or expired so the create
+ * project flow can prompt the user to (re-)authenticate instead of surfacing a
+ * raw error.
+ */
+class GitHubAuthException(message: String, cause: Throwable? = null) : Exception(message, cause)


### PR DESCRIPTION
## Summary

Fixes #80 — creating a new project with GitHub Releases fails with `java.io.IOException: Failed to create the repository. Response code:401 / Bad credentials`, and no GitHub login prompt ever appears so the user is stuck.

The root cause: a previously-stored GitHub token is reused without validation, and on a 401 the flow just throws a raw error with no way to re-authenticate. The login dialog only appeared when the stored account state was wiped (e.g. deleting `~/.jdeploy`).

## Changes (`NewProjectController`)

- **Validate before generating** — when project creation will create/push a GitHub repo, the token is checked against `GET /user` first (via `GitHubUsernameService`). A missing or rejected token raises `GitHubAuthException` instead of failing part-way through.
- **Recover from auth failures** — `done()` now detects GitHub 401 / "bad credentials" failures (including the raw `IOException` text from the CLI) and re-opens the account chooser so the user can pick or **add** a valid account, clearing the rejected token first, then retries automatically.
- **Clean up partial state** — before retrying, the partially-created project directory (and its `-releases` sibling) is removed so the retry isn't blocked by a "directory already exists" error.
- **Prompt gating** — `requiresGithubLogin()` now mirrors the exact condition under which a repo is actually created, so the chooser appears precisely when GitHub credentials are needed (no spurious prompts, no silent skips).

## New: Manage Accounts menu (`MainMenuViewController`)

Adds an **Accounts** menu to the main window ("Manage GitHub Accounts…" / "Manage npm Accounts…") that opens the existing account chooser, which supports add/edit/**delete**. Previously accounts were only reachable from inside the publish/new-project flows, so a user with a stale credential had no way to fix it. Deleting an account here is a complete cleanup (it clears both the stored record and the keyring token).

## Relationship to the CLI

This PR is self-contained and compiles/works against the current `jdeploy-cli` (it detects 401s from the existing `IOException` message). The companion CLI PR in **shannah/jdeploy** (branch `claude/sleepy-thompson-sl3q4`) adds a typed `GitHubAuthenticationException`, an option to skip repository creation, and rollback-on-failure; once released, the 401 detection here can be tightened to the typed exception.

## Testing

- `mvn test-compile` and `mvn test` — both pass.

https://claude.ai/code/session_0156xouo4EmaKjSihdHSDXxF

---
_Generated by [Claude Code](https://claude.ai/code/session_0156xouo4EmaKjSihdHSDXxF)_